### PR TITLE
Updated instructions for lab05

### DIFF
--- a/docs/05-monitoring-tracing.md
+++ b/docs/05-monitoring-tracing.md
@@ -21,7 +21,7 @@ In this exercise, you'll use Application Insights and distributed tracing to obs
 You'll run the same five test prompts against prompt versions v1, v2, and v3, then analyze the results from two angles:
 
 - **Azure Monitor**: Aggregated token usage and latency metrics across versions
-- **Microsoft Foundry Tracing**: Individual span trees per version, with per-prompt timing and attribute data
+- **Trace tree (local)**: A nested span tree per version from `python src/tests/check_traces.py`, with per-prompt timing and token attributes
 
 ## Set up the environment
 
@@ -131,7 +131,7 @@ With your Azure resources deployed, install the required Python packages.
     Open the `.env` file in your repository root and add:
 
     ```
-    MODEL_NAME=gpt-4.1
+    MODEL_NAME="gpt-4.1"
     ```
 
 ## Understand the monitoring script
@@ -178,7 +178,28 @@ Before running anything, take a moment to review what `src/tests/run_monitoring.
     - Does v3 produce noticeably longer responses than v1?
     - Does token count grow consistently from v1 to v3?
 
-    > **Note**: It may take a few minutes for monitoring data to appear in Azure Monitor and Microsoft Foundry after the script completes.
+1. View the trace tree for the latest run (recommended).
+
+    This lab uses a local trace viewer script that queries Log Analytics and prints a nested tree. This makes the parent/child chain very explicit without relying on a portal UI.
+
+    Run:
+
+    ```powershell
+    python src/tests/check_traces.py
+    ```
+
+    You should see one trace per prompt version, with three levels:
+
+    ```
+    trail_guide_v1                            ← root: entire version run
+    ├── v1_day-hike-gear                      ← child: one test prompt (duration + token attributes)
+    │   └── chat gpt-4.1                      ← auto: the actual LLM call
+    └── ...
+    trail_guide_v2  (same structure)
+    trail_guide_v3  (same structure)
+    ```
+
+    If the output says `No traces found yet`, wait 2–3 minutes and run the script again.
 
 ## View monitoring data in Azure Monitor
 
@@ -213,46 +234,48 @@ Focus on the **token usage** metrics and compare the three prompt versions:
 
 ### Compare the individual interactions
 
-1. In the navigation pane on the left, select **Tracing**.
-1. You'll see rows for each model call. Review the **Input**, **Output**, and **Duration** columns.
-1. Compare rows from `trail_guide_v1` spans against rows from `trail_guide_v3` spans.
+Use the output of `python src/tests/check_traces.py` to compare prompt versions.
+
+1. For the same test name (for example, `v1_trail-difficulty` vs `v3_trail-difficulty`), compare:
+    - **Duration** (shown in milliseconds)
+    - **Total tokens** (and prompt vs completion breakdown)
+1. Use the nested structure to understand the chain:
+    - The `v{n}_{test-name}` span is where you attach per-test token and duration attributes.
+    - The `chat gpt-4.1` span is the instrumented model call.
 
     - Which version produces the most consistent response lengths?
     - Which version shows the highest duration?
     - Are there any calls that stand out as unusually slow or verbose?
 
-## View trace data in Microsoft Foundry
+## View trace data
 
-The Tracing page gives you the full span tree for each version run — one parent span per version, with nested child spans for each test prompt and auto-instrumented LLM calls beneath those.
+The `check_traces.py` output gives you the full span tree for each version run — one root span per version, with nested child spans for each test prompt and auto-instrumented LLM calls beneath those.
 
 ### Review the version spans
 
-1. In the Tracing page, locate the three top-level spans: `trail_guide_v1`, `trail_guide_v2`, and `trail_guide_v3`.
-1. Select `trail_guide_v1` to open the span detail view.
+1. Run the trace viewer script:
 
-    You'll see a tree of nested spans:
-    - **`trail_guide_v1`** — the parent span for the entire version run
-        - **`v1_<test-name>`** — one child span per test prompt
-            - **`chat gpt-4.1`** — automatically added by OpenAIInstrumentor for the actual LLM call
+    ```powershell
+    python src/tests/check_traces.py
+    ```
 
-1. Select a `v1_<test-name>` span and review its **attributes**:
+1. Locate the root spans: `trail_guide_v1`, `trail_guide_v2`, and `trail_guide_v3`.
+1. Under each root span, locate a test child span like `v1_trail-difficulty`.
+1. Review the inline attributes printed on each test child span:
 
     | Attribute | What it tells you |
     |---|---|
-    | `prompt.version` | Which prompt version produced this response |
-    | `test.name` | Which test prompt was used |
-    | `response.total_tokens` | Total tokens consumed by this specific call |
-    | `response.duration_s` | Latency in seconds for this call |
-    | `session.id` | Groups all calls from the same script run |
+    | Span name (for example, `v3_trail-difficulty`) | Which prompt version + which test prompt |
+    | `[...]ms` | Latency for that span (milliseconds) |
+    | `tokens: total (↑prompt ↓completion)` | Token usage for that specific test call |
 
 ### Compare span trees across versions
 
-1. Navigate back to the Tracing list and open `trail_guide_v3`.
-1. Select the same test (e.g. `v3_trail-difficulty`) and compare its attributes to the equivalent `v1_trail-difficulty` span.
+1. Compare `trail_guide_v3` to `trail_guide_v1` for the same test (for example, `v3_trail-difficulty` vs `v1_trail-difficulty`).
 
-    - Is `response.completion_tokens` higher in v3?
-    - Is `response.duration_s` longer?
-    - Open the auto-instrumented `chat gpt-4.1` child span and review the captured prompt and response content.
+    - Are completion tokens higher in v3?
+    - Is the duration longer?
+    - Compare the `chat gpt-4.1` child span durations under each test span.
 
 1. Repeat the comparison for at least two other test prompts. Document your observations:
 
@@ -285,7 +308,7 @@ If you completed [Lab 03: Design and optimize prompts](03-design-optimize-prompt
     python src/tests/run_monitoring.py
     ```
 
-1. In Azure AI Foundry Tracing, compare the new `trail_guide_v4_optimized_concise` span tree against `trail_guide_v3`.
+1. Run `python src/tests/check_traces.py` again and compare the new `trail_guide_v4_optimized_concise` span tree against `trail_guide_v3`.
 
     - Does the token reduction you measured in evaluation hold up at runtime?
     - Is there a latency improvement as well?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,17 @@
 # GenAI Operations Dependencies - Trail Guide Agent
 # Adventure Works Outdoor Gear - AI Trail Assistant
-# Updated: 2026-01-16
+# Updated: 2026-03-04
 
 # Core Azure AI Projects SDK (Pinned for compatibility)
 azure-ai-projects==2.0.0b4
 azure-identity==1.25.2
 azure-core==1.38.2
 azure-mgmt-resource>=23.0.0
+azure-mgmt-applicationinsights>=4.0.0
+azure-mgmt-loganalytics>=13.0.0
+azure-mgmt-subscription>=3.1.1
 azure-monitor-opentelemetry==1.8.6
+azure-monitor-query>=1.4.0
 opentelemetry-instrumentation-openai-v2==2.3b0
 openai==2.24.0
 

--- a/src/tests/check_traces.py
+++ b/src/tests/check_traces.py
@@ -1,0 +1,184 @@
+"""Verify that traces from run_monitoring.py reached Application Insights.
+
+Queries Log Analytics directly to confirm spans are being exported,
+bypassing the Azure AI Foundry portal which has a ~5-10 minute display lag.
+
+Usage:
+    python src/tests/check_traces.py
+"""
+import os
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.monitor.query import LogsQueryClient, LogsQueryStatus
+from azure.mgmt.applicationinsights import ApplicationInsightsManagementClient
+from azure.mgmt.subscription import SubscriptionClient
+from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+from azure.ai.projects import AIProjectClient
+from datetime import timedelta
+
+load_dotenv()
+
+credential = DefaultAzureCredential()
+
+# Resolve the Application Insights connection string from the Foundry project
+project_endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
+project_client = AIProjectClient(endpoint=project_endpoint, credential=credential)
+connection_string = project_client.telemetry.get_application_insights_connection_string()
+
+if not connection_string:
+    print("ERROR: No Application Insights connection string found.")
+    print("Ensure Application Insights is linked to your AI Foundry project.")
+    raise SystemExit(1)
+
+# Extract the InstrumentationKey from the connection string
+instrumentation_key = next(
+    part.split("=", 1)[1]
+    for part in connection_string.split(";")
+    if part.startswith("InstrumentationKey")
+)
+print(f"Application Insights key: {instrumentation_key}")
+
+# Resolve Log Analytics workspace customer ID (required by LogsQueryClient)
+print("Resolving Log Analytics workspace...")
+sub_client = SubscriptionClient(credential)
+subscription_id = next(sub_client.subscriptions.list()).subscription_id
+
+ai_mgmt = ApplicationInsightsManagementClient(credential, subscription_id)
+workspace_resource_id = None
+for component in ai_mgmt.components.list():
+    if instrumentation_key in (component.instrumentation_key or ""):
+        workspace_resource_id = component.workspace_resource_id
+        break
+
+if not workspace_resource_id:
+    print("ERROR: Could not find a matching Application Insights component in your subscription.")
+    raise SystemExit(1)
+
+resource_group = workspace_resource_id.split("/")[4]
+workspace_name = workspace_resource_id.split("/")[-1]
+
+la_client = LogAnalyticsManagementClient(credential, subscription_id)
+workspace = la_client.workspaces.get(resource_group, workspace_name)
+workspace_id = workspace.customer_id
+print(f"Workspace ID: {workspace_id}\n")
+
+# A single run_monitoring.py execution produces one trace per prompt version.
+# Each trace contains a root span (trail_guide_v{n}), test child spans
+# (v{n}_{test-name}), and auto-instrumented OpenAI spans (chat gpt-4.1).
+#
+# Id / ParentId / OperationId are used to reconstruct the tree.
+# Custom attributes (prompt.version, response.* tokens) live in Properties.
+#
+# Note: the query filters to the latest run to avoid mixing multiple executions.
+query = """
+let latest_root_time = toscalar(
+    AppDependencies
+    | where TimeGenerated > ago(6h)
+    | where Name startswith "trail_guide_"
+    | top 1 by TimeGenerated desc
+    | project TimeGenerated
+);
+let ops_in_latest_run = AppDependencies
+    | where TimeGenerated between (latest_root_time - 15m .. latest_root_time + 2m)
+    | where Name startswith "trail_guide_"
+    | distinct OperationId;
+AppDependencies
+| where TimeGenerated > ago(6h)
+| where OperationId in (ops_in_latest_run)
+| summarize arg_max(TimeGenerated, *) by Id
+| project
+    Id,
+    ParentId,
+    OperationId,
+    Name,
+    DurationMs,
+    Success,
+    PromptVersion    = tostring(Properties["prompt.version"]),
+    TestName         = tostring(Properties["test.name"]),
+    TotalTokens      = tostring(Properties["response.total_tokens"]),
+    PromptTokens     = tostring(Properties["response.prompt_tokens"]),
+    CompletionTokens = tostring(Properties["response.completion_tokens"])
+"""
+
+print("Querying spans from the past 6 hours and building the tree for the latest run...\n")
+logs_client = LogsQueryClient(credential)
+result = logs_client.query_workspace(
+    workspace_id=workspace_id,
+    query=query,
+    timespan=timedelta(hours=6),
+)
+
+if result.status != LogsQueryStatus.SUCCESS:
+    print(f"Query error: {result.partial_error}")
+    raise SystemExit(1)
+
+rows = result.tables[0].rows
+if not rows:
+    print("No traces found yet — wait 2-3 more minutes and run again.")
+    raise SystemExit(0)
+
+# Build a lookup of span_id → span dict, and a children map
+spans = {}
+children = {}
+for row in rows:
+    span_id, parent_id, op_id, name, dur, ok, version, test_name, total, prompt, compl = row
+    spans[span_id] = {
+        "id": span_id,
+        "parent": parent_id,
+        "op": op_id,
+        "name": name,
+        "dur": dur,
+        "ok": ok,
+        "version": version or "",
+        "test": test_name or "",
+        "total": total or "",
+        "prompt": prompt or "",
+        "compl": compl or "",
+    }
+    children.setdefault(parent_id, []).append(span_id)
+
+# Identify root spans (ParentId not in any span's Id)
+all_ids = set(spans.keys())
+roots = [s for s in spans.values() if s["parent"] not in all_ids]
+# Sort roots by operation ID so versions appear in order
+roots.sort(key=lambda s: s["op"])
+
+
+def print_span(span_id, prefix="", is_last=True):
+    """Recursively print a span and its children as an ASCII tree."""
+    span = spans[span_id]
+    connector = "└── " if is_last else "├── "
+    name_str = span["name"]
+
+    # Build inline annotation for test child spans
+    details = ""
+    if span["total"]:
+        details = (
+            f"  [{span['dur']}ms | "
+            f"tokens: {span['total']} (↑{span['prompt']} ↓{span['compl']})]"
+        )
+    elif span["dur"]:
+        details = f"  [{span['dur']}ms]"
+
+    print(f"{prefix}{connector}{name_str}{details}")
+
+    kids = sorted(children.get(span_id, []), key=lambda k: spans[k]["name"])
+    child_prefix = prefix + ("    " if is_last else "│   ")
+    for i, kid in enumerate(kids):
+        print_span(kid, child_prefix, is_last=(i == len(kids) - 1))
+
+
+# Print one tree per trace (operation)
+seen_ops = []
+for root in roots:
+    if root["op"] in seen_ops:
+        continue
+    seen_ops.append(root["op"])
+    print(f"Trace: {root['op']}")
+    # Find all root spans for this operation
+    op_roots = [s for s in roots if s["op"] == root["op"]]
+    for i, r in enumerate(op_roots):
+        print_span(r["id"], prefix="", is_last=(i == len(op_roots) - 1))
+    print()
+
+print(f"Total spans found: {len(spans)}")

--- a/src/tests/run_monitoring.py
+++ b/src/tests/run_monitoring.py
@@ -28,9 +28,6 @@ project_endpoint = os.environ["AZURE_AI_PROJECT_ENDPOINT"]
 openai_endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
 model_name = os.getenv("MODEL_NAME", "gpt-4.1")
 
-# Enable prompt and response content capture in spans
-os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
-
 # Connect to Azure AI Project and retrieve Application Insights connection string
 project_client = AIProjectClient(
     endpoint=project_endpoint,


### PR DESCRIPTION
This PR improves the monitoring + tracing lab by making trace verification reliable and easy to run locally.

- Updates `src/tests/run_monitoring.py` to align span attributes/usage with the latest SDK + instrumentation behavior.
- Adds `src/tests/check_traces.py`, a local trace viewer that queries Application Insights via Log Analytics and prints a nested span tree for the **latest** run (avoids portal timing/refresh issues).
- Updates `docs/05-monitoring-tracing.md` to use `check_traces.py` as the primary way to view and compare traces, including the parent → test → LLM call chain.

## Why

Portal-based tracing can be delayed or confusing during labs. `check_traces.py` provides a repeatable way for students to confirm tracing is working and understand the span hierarchy.