### PR TITLE
Update service principal creation command and use env variable for Subscription ID

### DIFF
--- a/docs/04-automated-evaluation.md
+++ b/docs/04-automated-evaluation.md
@@ -402,10 +402,10 @@ The evaluation script integrates with GitHub Actions to automatically run evalua
     Create a service principal for GitHub Actions:
 
     ```powershell
-    az ad sp create-for-rbac --name "github-agent-evaluator"
+    az ad sp create-for-rbac --name "github-agent-evaluator" --create-password false
     ```
 
-    Save the `appId` and `tenant` values from the output. The workflow below uses OIDC federated credentials, so the generated `password` is not used in this lab.
+    Save the `appId` and `tenant` values from the output. The workflow below uses OIDC federated credentials. The `--create-password false` is included as your Entra ID tenant might have applied basline security mode defaults, specifically `Block new password credentials in apps` which would throw a policy error.
 
     Assign the **Foundry User** role so the service principal can call the Foundry project API:
 

--- a/src/tests/check_traces.py
+++ b/src/tests/check_traces.py
@@ -40,8 +40,7 @@ print(f"Application Insights key: {instrumentation_key}")
 
 # Resolve Log Analytics workspace customer ID (required by LogsQueryClient)
 print("Resolving Log Analytics workspace...")
-sub_client = SubscriptionClient(credential)
-subscription_id = next(sub_client.subscriptions.list()).subscription_id
+subscription_id = os.environ.get("AZURE_SUBSCRIPTION_ID")
 
 ai_mgmt = ApplicationInsightsManagementClient(credential, subscription_id)
 workspace_resource_id = None


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Reduces some of the friction while going through the lab.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

The first change is related to a policy error generating a password (if the end user has enabled the baseline security mode - 'block new password credentials in apps'. The password is not actually required for the lab so this avoids an error message being displayed.

The second change relates to an end user with multiple Azure Subscriptions; the code is unable to determine which subscription Application Insights is located in and throws 'ERROR: Could not find a matching Application Insights component in your subscription'. The subscription id exists as an environment variable, so this avoids the error all together.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1. Create the service principal with the new parameter added to the command line, note no policy error
2. After running 'azd up', followed by 'azd env get-values > .env' verify check_traces.py in the 'Monitor and trace your generative AI agent' exercise.


* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid

'az ad sp create-for-rbac' command no longer creates a password
python src/tests/check_traces.py finds the correct Application Insights component


## Other Information
<!-- Add any other helpful information that may be needed here. -->

A few paper cuts I found while doing the exercises.